### PR TITLE
Fix Android "Configuration 'compile' is obsolete" warning & upgrade Glide API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "javascript.preferences.quoteStyle": "single",
-  "editor.formatOnSave": false
+  "editor.formatOnSave": false,
+  "java.configuration.updateBuildConfiguration": "disabled"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,18 +37,17 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 
     // glide dependencies
-    compile 'com.github.bumptech.glide:glide:4.2.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.2.0'
+    implementation 'com.github.bumptech.glide:glide:4.2.0'
 
     // FirebaseUI Storage only
-    compile 'com.firebaseui:firebase-ui-storage:3.0.0'
+    implementation 'com.firebaseui:firebase-ui-storage:3.0.0'
 
     // PhotoView
-    compile 'com.github.chrisbanes:PhotoView:2.1.3'
+    implementation 'com.github.chrisbanes:PhotoView:2.1.3'
 
     // glide-transformations
-    compile 'jp.wasabeef:glide-transformations:3.0.1'
+    implementation 'jp.wasabeef:glide-transformations:3.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,6 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 buildscript {
     repositories {
@@ -12,12 +15,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "25.0.3"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', "25.0.3")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
     }

--- a/android/src/main/java/io/rumors/reactnativefirebaseui/storage/ExtendedImageView.java
+++ b/android/src/main/java/io/rumors/reactnativefirebaseui/storage/ExtendedImageView.java
@@ -22,7 +22,7 @@ import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
 import com.bumptech.glide.load.MultiTransformation;
 import com.bumptech.glide.signature.MediaStoreSignature;
-import static com.bumptech.glide.request.RequestOptions.bitmapTransform;
+import com.bumptech.glide.request.RequestOptions;
 
 import jp.wasabeef.glide.transformations.RoundedCornersTransformation;
 import jp.wasabeef.glide.transformations.RoundedCornersTransformation.CornerType;
@@ -85,12 +85,12 @@ public class ExtendedImageView extends ImageView {
 
     MultiTransformation multi = new MultiTransformation<>(transformationsArray);
 
-    GlideApp.with(mContext)
+    Glide .with(mContext)
             .load(storageReference)
-            .placeholder(mDefaultImageDrawable)
-            .apply(bitmapTransform(multi))
+            .apply(new RequestOptions().placeholder(mDefaultImageDrawable))
+            .apply(new RequestOptions().bitmapTransform(multi))
             //(String mimeType, long dateModified, int orientation)
-            .signature(new MediaStoreSignature("", mTimestamp, 0))
+            .apply(new RequestOptions().signature(new MediaStoreSignature("", mTimestamp, 0)))
             .into(this);
   }
 }

--- a/android/src/main/java/io/rumors/reactnativefirebaseui/storage/ExtendedPhotoView.java
+++ b/android/src/main/java/io/rumors/reactnativefirebaseui/storage/ExtendedPhotoView.java
@@ -22,7 +22,7 @@ import com.bumptech.glide.load.resource.bitmap.FitCenter;
 import com.bumptech.glide.load.resource.bitmap.CenterCrop;
 import com.bumptech.glide.load.MultiTransformation;
 import com.bumptech.glide.signature.MediaStoreSignature;
-import static com.bumptech.glide.request.RequestOptions.bitmapTransform;
+import com.bumptech.glide.request.RequestOptions;
 
 import jp.wasabeef.glide.transformations.RoundedCornersTransformation;
 import jp.wasabeef.glide.transformations.RoundedCornersTransformation.CornerType;
@@ -84,12 +84,12 @@ public class ExtendedPhotoView extends PhotoView {
     Transformation[] transformationsArray = transformations.toArray(new Transformation[transformations.size()]);
     MultiTransformation multi = new MultiTransformation<>(transformationsArray);
 
-    GlideApp.with(mContext)
+    Glide.with(mContext)
             .load(storageReference)
-            .placeholder(mDefaultImageDrawable)
-            .apply(bitmapTransform(multi))
+            .apply(new RequestOptions().placeholder(mDefaultImageDrawable))
+            .apply(new RequestOptions().bitmapTransform(multi))
             //(String mimeType, long dateModified, int orientation)
-            .signature(new MediaStoreSignature("", mTimestamp, 0))
+            .apply(new RequestOptions().signature(new MediaStoreSignature("", mTimestamp, 0)))
             .into(this);
   }
 }


### PR DESCRIPTION
Hi, this PR has no prio, but fixes two things:

- On Android builds, it fixes the warning "WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'."
- Because "compile" was replaced by "implementation", the `annotationProcessor` command resulted in errors. I solved this by upgrading the Glide code to use the new "Glide" API, which doesn't require the annotation
- Thirdly, the Android build versions have been made "future-proof" and uses the versions from your app if possible

cheers