### PR TITLE
Fixed SDImageCache compile errors with latest SDWebImage

### DIFF
--- a/ios/UIImageView+FirebaseStorage.h
+++ b/ios/UIImageView+FirebaseStorage.h
@@ -17,8 +17,7 @@
 @import UIKit;
 #import <UIKit/UIKit.h>
 #import <FirebaseStorage/FirebaseStorage.h>
-#import <SDWebImage/UIImageView+WebCache.h>
-#import <SDWebImage/UIImage+MultiFormat.h>
+#import <SDWebImage/SDWebImage.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Hi! This PR fixes a compile error existent with the latest SDWebImage package. The imports that are used, no longer pull-in the SDImageCache class which causes a compile error. 
I've updated the imports to use the import-directive that is specified on the SDWebImage github page and that works correctly.

![image](https://user-images.githubusercontent.com/6184593/65863017-b0499c80-e36f-11e9-9c7a-d9e893b9ea24.png)
