### PR TITLE
Fixed android build for AndroidX and RN0.60 (upgraded Glide)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
 
     // glide dependencies
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.10.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.10.0'
 
     // FirebaseUI Storage only
     implementation 'com.firebaseui:firebase-ui-storage:3.0.0'


### PR DESCRIPTION
Hi! This PR fixes a build error on Android with Glide, when using AndroidX/RN60. It basically just upgraded Glide to the latest version which fixes all the build problems.
Cheers!